### PR TITLE
#95 gave issue ClassCastException: jnr.posix.WindowsFileStat cannot be cast

### DIFF
--- a/src/main/java/jnr/posix/WindowsPOSIX.java
+++ b/src/main/java/jnr/posix/WindowsPOSIX.java
@@ -318,7 +318,8 @@ final public class WindowsPOSIX extends BaseNativePOSIX {
     }
 
     public FileStat fstat(int fd) {
-        WindowsFileStat stat = new WindowsFileStat(this);
+        //WindowsFileStat stat = new WindowsFileStat(this);
+	WindowsRawFileStat stat = new WindowsRawFileStat(this,this.handler);
         if (fstat(fd, stat) < 0) handler.error(Errno.valueOf(errno()), "fstat", "" + fd);
         return stat;
     }


### PR DESCRIPTION
Was receiving the following after looking @ #95

```
java.lang.ClassCastException: jnr.posix.WindowsFileStat cannot be cast
to jnr.posix.WindowsRawFileStat
        at jnr.posix.WindowsPOSIX.fstat(WindowsPOSIX.java:337)
        at jnr.posix.WindowsPOSIX.fstat(WindowsPOSIX.java:329)
        at jnr.posix.WindowsPOSIX.fstat(WindowsPOSIX.java:322)
        at jnr.posix.CheckedPOSIX.fstat(CheckedPOSIX.java:125)
        at jnr.posix.LazyPOSIX.fstat(LazyPOSIX.java:122)
        at jnr.posix.FileStatTest.filestatInt(FileStatTest.java:133)
```

change it using `WindowsRawFileStat` which was being expected